### PR TITLE
fix(docs): fix minimum ECMAScript language support in Readme to ES2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Previous versions of node *may* work, but they are not tested by OpenTelemetry a
 Rather than define versions of specific browsers / runtimes, OpenTelemetry sets the minimum supported version based on the
 underlying language features used.
 
-The current minumum language feature support is set as [ECMAScript 2020](https://262.ecma-international.org/11.0/) that are available
+The current minumum language feature support is set as [ECMAScript 2022](https://262.ecma-international.org/13.0/) that are available
 in all modern browsers / runtimes.
 
 This means that if you are targeting or your end-users are using a browser / runtime that does not support ES2022, you will need


### PR DESCRIPTION
## Which problem is this PR solving?

* Unify minimum language feature support in Readme to ES2022

Fixes #5773

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

n/a

## Checklist:

- [x] Documentation has been updated
